### PR TITLE
Get rid of infinite loop due to with-exception-handler not bailing out.

### DIFF
--- a/tests/run.scm
+++ b/tests/run.scm
@@ -38,12 +38,10 @@
 
  ;; test acl
  (test-assert "Acl Put String" (put-string! *b* "string" "res-string"))
- (with-exception-handler
-  (lambda (x) (set! got-403 #t))
-  (lambda ()
-    (with-input-from-request
-     "https://s3.amazonaws.com/chicken-scheme-test-bucket-1/string"
-     #f (lambda () #t))))
+ (handle-exceptions x (set! got-403 #t)
+   (with-input-from-request
+    "https://s3.amazonaws.com/chicken-scheme-test-bucket-1/string"
+    #f (lambda () #t)))
  (test-assert got-403)
  (test-assert "Delete Object 3" (delete-object! *b* "string"))
  (test-assert "Acl Put String"


### PR DESCRIPTION
As mentioned in the documentation, with-exception-handler requires the
user to capture a continuation to jump out of the error situation.  If
this doesn't happen, an exception will be raised, which invokes the
same exception handler, and so on.

This resulted in all Salmonella runs hanging.

PS: It looks like the tests actually connect to a live Amazon S3 server, using an account that's no longer active. This results in 403 on each request, which causes the tests to fail (I verified this using another client, `s3cmd`).  Could it be that this was an account owned by Thomas Hintz?

It's best not to rely on an actual live server, but for this particular egg that's a bit hard to avoid because otherwise you'd be mocking out the entire service, "dry testing" against your own code, which doesn't provide much of an assurance that it would work against an actual server.  Maybe somewhere we can get a free test account, or use an independent mock library like [s3ninja](http://s3ninja.net/) (note: never tried it myself), or install [OpenStack Swift with S3 support](https://github.com/openstack/swift3) somewhere and delete all the data hourly or something?