### PR TITLE
Replace uri construction by procedure parameter; use https by default

### DIFF
--- a/amazon-s3.scm
+++ b/amazon-s3.scm
@@ -283,7 +283,7 @@
 
 (define (put-sexp! bucket key sexp #!key (acl #f))
   (let-values (((res request-uri response)
-                (put-string! bucket key (->string sexp) acl: acl)))
+                (put-string! bucket key (sprintf "~S" sexp) acl: acl)))
     (values res request-uri response)))
 
 

--- a/amazon-s3.scm
+++ b/amazon-s3.scm
@@ -7,7 +7,7 @@
    *last-sig*
 
    ;; params
-   access-key secret-key https s3-base-host
+   access-key secret-key https make-base-uri
 
    ;; procs
    list-objects
@@ -59,8 +59,17 @@
 
 (define access-key (make-parameter ""))
 (define secret-key (make-parameter ""))
-(define https (make-parameter #f))
-(define s3-base-host (make-parameter "s3.amazonaws.com"))
+
+;; DEPRECATED
+(define https (make-parameter #t))
+
+(define make-base-uri
+  (make-parameter
+   (lambda (bucket)
+     (make-uri scheme: (if (https) 'https 'http)
+               host: (if bucket
+                         (string-append bucket "." "s3.amazonaws.com")
+                         "s3.amazonaws.com")))))
 
 ;;; helper methods
 
@@ -129,19 +138,10 @@
                      (content-type "")
                      (content-length 0)
                      (acl #f))
-  (let* ((host (if bucket
-                   (string-append bucket "." (s3-base-host))
-                   (s3-base-host)))
-         (base (make-uri scheme: (if (https) 'https 'http) host: host))
-         ;; We parse the path as URI, then ensuring it is an absolute
-         ;; path.  This is far from ideal, but it works.
+  (let* ((base ((make-base-uri) bucket))
          (path-ref (uri-reference path))
-         (abs-path (and path-ref
-                        (if (uri-path-absolute? path-ref)
-                            (uri-path path-ref)
-                            `(/ ,@(uri-path path-ref)))))
-         ;; Add path and query
-         (final-uri (update-uri base path: abs-path query: query)))
+         (uri/path (if path-ref (uri-relative-to path-ref base) base))
+         (final-uri (update-uri uri/path query: query)))
     (make-request
      method: (string->symbol verb)
      uri: final-uri

--- a/amazon-s3.scm
+++ b/amazon-s3.scm
@@ -118,9 +118,9 @@
     (let-values (((hmac-sha1 can-string)
                   (make-aws-authorization
                    verb
-                   (string-append "/"
-                                  (if bucket (string-append bucket "/") "")
-                                  (or path ""))
+                   (uri->string
+                    (make-uri path: `(/ ,@(if bucket (list bucket) '())
+                                        ,(or path ""))))
                    date: (sig-date n)
                    content-type: content-type
                    amz-headers: (if acl (list (cons "X-Amz-Acl" acl)) '()))))
@@ -139,7 +139,7 @@
                      (content-length 0)
                      (acl #f))
   (let* ((base ((make-base-uri) bucket))
-         (path-ref (uri-reference path))
+         (path-ref (and path (make-uri path: (list path))))
          (uri/path (if path-ref (uri-relative-to path-ref base) base))
          (final-uri (update-uri uri/path query: query)))
     (make-request

--- a/amazon-s3.scm
+++ b/amazon-s3.scm
@@ -292,8 +292,9 @@
                (file-size file-path) "binary/octet-stream" acl: acl))
 
 
-(define (get-object bucket key)
-  (perform-aws-request bucket: bucket path: key no-xml: #t))
+(define (get-object bucket key #!optional (reader read-string))
+  (perform-aws-request
+   bucket: bucket path: key no-xml: #t reader-thunk: reader))
 
 
 (define (get-string bucket key)

--- a/tests/run.scm
+++ b/tests/run.scm
@@ -42,6 +42,13 @@
  (test "List Bucket Objects w/ prefix" '("key") (list-objects *b* prefix: "k"))
  (test-assert "Delete Object 1" (delete-object! *b* "key"))
  (test-assert "Delete Object 2" (delete-object! *b* "string"))
+
+ (test "Object key encoding" (put-string! *b* "//12%456%2F?78#9aB" "x"))
+ (test "List Bucket objects returns same key name"
+       '("//12%456%2F?78#9aB") (list-objects *b*))
+ (test-assert "Delete encoded object"
+              (delete-object! *b* "//12%456%2F?78#9aB"))
+
  (test-assert "Put Sexp" (put-sexp! *b* "sexp" '(+ 1 2 3)))
  (test "Get Sexp" 6 (eval (get-sexp *b* "sexp")))
  (test-assert "Put File" (put-file! *b* "file" "file"))

--- a/tests/run.scm
+++ b/tests/run.scm
@@ -51,6 +51,12 @@
 
  (test-assert "Put Sexp" (put-sexp! *b* "sexp" '(+ 1 2 3)))
  (test "Get Sexp" 6 (eval (get-sexp *b* "sexp")))
+
+ ;; Regression test for storing (->string value), which would store the
+ ;; string itself rather than the string representation of the sexp.
+ (test-assert "Put Sexp string" (put-sexp! *b* "sexp" "(+ 1 2 3)"))
+ (test "Get Sexp string" "(+ 1 2 3)" (eval (get-sexp *b* "sexp")))
+
  (test-assert "Put File" (put-file! *b* "file" "file"))
  (test-assert "Get File" (get-file *b* "file" "test-out-file"))
  (test "Get/Put File 1" #t

--- a/tests/run.scm
+++ b/tests/run.scm
@@ -35,6 +35,9 @@
  ;; (test-assert "List Buckets" (list-buckets)) ; should test this more speci
  (test "List Bucket Objects 1" '() (list-objects *b*))
  (test-assert "Put Object" (put-object! *b* "key" (lambda () (display "value")) (string-length "value") "text/plain"))
+ (test "Get Object"
+       '(#\v #\a #\l #\u #\e)
+       (get-object *b* "key" (lambda () (string->list (read-string)))))
  (test "List Bucket Objects 2" '("key") (list-objects *b*))
  (test-assert "Put String" (put-string! *b* "string" "res-string"))
  (test "Get String" "res-string" (get-string *b* "string"))


### PR DESCRIPTION
This new parameter accepts a bucket and creates a base URI.  This
allows for more flexible handling of base URIs; for example, Ceph
support two methods of indicating the bucket; either as the first path
component or as the first hostname component.  The former is even the
approach [recommended by the Ceph documentation](http://docs.ceph.com/docs/master/radosgw/s3/commons/), but it's incompatible
with the original Amazon API!

Anyway, we still use the old `https` parameter in the default
implementation of this new `make-base-uri` parameter, for backwards
compatibility, but now it defaults to `#t` for improved security and privacy.
The parameter is also deprecated: it will be removed in a future version.