### PR TITLE
Add test dependency on openssl

### DIFF
--- a/amazon-s3.meta
+++ b/amazon-s3.meta
@@ -9,7 +9,8 @@
 
 (needs base64 sha1 http-client uri-common intarweb srfi-19 hmac ssax sxpath)
 
-(test-depends test)
+;; openssl is necessary for tests because the default endpoints are HTTPS
+(test-depends test openssl)
 
 (author "Thomas Hintz")
 (maintainer "Seth Alves")


### PR DESCRIPTION
This ensures the tests run without issue on Salmonella (or when running them manually, for that matter)

See https://salmonella-linux-x86-64.call-cc.org/chicken-4/gcc/linux/x86-64/2018/04/29/salmonella-report/test/amazon-s3.html